### PR TITLE
docs: fix the Git repository URL

### DIFF
--- a/cell-tower-anomaly-detection/README.md
+++ b/cell-tower-anomaly-detection/README.md
@@ -58,7 +58,7 @@ SPARK_SUBNET_CIDR="10.0.0.0/16"
 ## 6. Clone this repo
 ```
 cd ~
-git clone https://github.com/googlecloudplatform/serverless-spark-workshop/lab-01.git
+git clone https://github.com/googlecloudplatform/serverless-spark-workshop.git
 ```
 
 ## 7. Upload the code and data to the designated GCS bucket


### PR DESCRIPTION
Hello, this PR fixes a typo of the Git repository URL in `README.md`.

The original URL raises not found error:
```shell
> git clone https://github.com/googlecloudplatform/serverless-spark-workshop/lab-01.git
Cloning into 'lab-01'...
remote: Not Found
fatal: repository 'https://github.com/googlecloudplatform/serverless-spark-workshop/lab-01.git/' not found
```